### PR TITLE
Added method to set time with http.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ The format of the _installer-config.txt_ file and the current defaults:
     rootsize=                 # / partition size in megabytes, provide it in the form '+<number>M' (without quotes),
                               #   leave empty to use all free space
     timeserver=time.nist.gov
+    timeserver_http=          # Url that returns the time in the format: YYYY-MM-DD HH:MM:SS.
+
     disable_predictable_nin=1 # Disable Predictable Network Interface Names. Set to 0 if you want to use predictable
                               #   network interface names, which means if you use the same SD card on a different
                               #   RPi board, your network device might be named differently. This will result in the

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -463,6 +463,17 @@ if [ "$date_set" = "false" ]; then
             fi
         done
     fi
+
+    if [ "$date_set" = "false" ]; then
+        # Try to set time via http to work behind proxies.
+        http_time="$(wget -O - "http://www.timeapi.org/utc/now?format=%25F+%25T")"
+        if date -u -s "$http_time"; then
+            echo -n "Time set using http://www.timeapi.org to ... "
+            date_set=true
+        else
+            echo "Failed to set time using http://www.timeapi.org."
+        fi
+    fi
 fi
 if [ "${date_set}" = "false" ]; then
     echo "FAILED to set the date, so things are likely to fail now ..."

--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -28,6 +28,7 @@ bootsize=+128M
 bootoffset=8192
 rootsize=
 timeserver=time.nist.gov
+timeserver_http=http://chronic.herokuapp.com/utc/now?format=%25F+%25T
 timezone=Etc/UTC
 locales=
 system_default_locale=
@@ -466,13 +467,21 @@ if [ "$date_set" = "false" ]; then
 
     if [ "$date_set" = "false" ]; then
         # Try to set time via http to work behind proxies.
-        http_time="$(wget -O - "http://www.timeapi.org/utc/now?format=%25F+%25T")"
-        if date -u -s "$http_time"; then
-            echo -n "Time set using http://www.timeapi.org to ... "
-            date_set=true
-        else
-            echo "Failed to set time using http://www.timeapi.org."
-        fi
+        # Timeserver has to return the time in the format: YYYY-MM-DD HH:MM:SS.
+        timeservers_http="$timeserver_http"
+        timeservers_http="$timeservers_http http://chronic.herokuapp.com/utc/now?format=%25F+%25T"
+        timeservers_http="$timeservers_http http://www.timeapi.org/utc/now?format=%25F+%25T"
+        for ts_http in $timeserver_http
+        do
+            echo -n "Time set using '$ts_http' to ... "
+            http_time="$(wget -q -O - "${timeserver_http}")"
+            if date -u -s "$http_time"; then
+                date
+                date_set=true
+            else
+                echo "failed"
+            fi
+        done
     fi
 fi
 if [ "${date_set}" = "false" ]; then


### PR DESCRIPTION
Added an additional method to set the time via http when ntpdate and rdate both fail. This is usefull when you're behind a proxy that only works with http and have configured your proxy in install-config.txt with export http_proxy="". Or if you're behind a firewall that blocks everything else than http.
