### PR TITLE
Fixed broken set time with http feature.

### DIFF
--- a/scripts/etc/init.d/rcS
+++ b/scripts/etc/init.d/rcS
@@ -472,7 +472,7 @@ if [ "$date_set" = "false" ]; then
         echo -n "Set time using HTTP timeserver "
         for ts_http in $timeservers_http; do
             echo -n "'$ts_http'... "
-            http_time="$(wget -q -O - "${timeserver_http}")"
+            http_time="$(wget -q -O - "${ts_http}")"
             if date -u -s "$http_time"; then
                 echo "OK"
                 date_set=true


### PR DESCRIPTION
Bug fix

Installation output:

```
Configuring eth0 with static ip 192.168.178.2... OK
Set time using ntpdate... Failed to set time via ntpdate. Switched to rdate.
Set time using timeserver 'time.nist.gov'... 'time.nist.gov'... 'nist1.symmetricom.com'... 'nist-time-server.eoni.com'... 'utcnist.colorado.edu'... 'nist1-pa.ustiming.org'... 'nist.expertsmi.com'... 'nist1-macon.macon.ga.us'... 'wolfnisttime.com'... 'nist.time.nosc.us'... 'nist.netservicesgroup.com'... 'nisttime.carsoncity.k12.mi.us'... 'nist1-lnk.binary.net'... 'ntp-nist.ldsbc.edu'... 'utcnist2.colorado.edu'... 'nist1-ny2.ustiming.org'... 'wwv.nist.gov'... Failed to set time via rdate. Switched to HTTP.
Set time using HTTP timeserver 'http://chronic.herokuapp.com/utc/now?format=%25F+%25T'... Fri Sep 30 14:18:25 UTC 2016
OK
Time (UTC): Fri Sep 30 14:18:25 UTC 2016

Installation started at Fri Sep 30 14:18:12 UTC 2016.
```
