### PR TITLE
rm build_dir from previous build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -637,7 +637,7 @@ fi
 
 # Prepare
 
-rm -rf tmp && mkdir -p ${build_dir} && cd ${build_dir}
+rm -rf ${build_dir} && mkdir -p ${build_dir} && cd ${build_dir}
 rm -rf tmp && mkdir tmp
 
 # extract debs


### PR DESCRIPTION
`tmp` is already removed in the next line so I'm guessing you want to remove `${build_dir}` here to prevent left-overs from a previous build.