### PR TITLE
fix the SHA256SUMS generated file format

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -295,7 +295,7 @@ add_packages() {
 				printf "  %-32s %s\n" "${current_package}" "$(basename "${current_filename}")"
 				unset_required "${current_package}"
 				packages_debs+=("${2}/${current_filename}")
-				packages_sha256+=("${current_sha256} $(basename "${current_filename}")")
+				packages_sha256+=("${current_sha256}  $(basename "${current_filename}")")
 				allfound && break
 			fi
 


### PR DESCRIPTION
The SHA256SUMS has 2 spaces in its format, as the checksum was calculated in
text mode.

See: http://unix.stackexchange.com/a/139892