### PR TITLE
FAT32 boot file system compatibility fix for RPi Compute Module 3.

### DIFF
--- a/scripts/opt/raspberrypi-ua-netinst/install.sh
+++ b/scripts/opt/raspberrypi-ua-netinst/install.sh
@@ -1483,9 +1483,9 @@ mdev -s
 
 echo -n "Initializing /boot as vfat... "
 if [ -z "${boot_volume_label}" ]; then
-	mkfs.vfat "${bootpartition}" &> /dev/null || fail
+	mkfs.vfat -s 1 "${bootpartition}" &> /dev/null || fail
 else
-	mkfs.vfat -n "${boot_volume_label}" "${bootpartition}" &> /dev/null || fail
+	mkfs.vfat -s 1 -n "${boot_volume_label}" "${bootpartition}" &> /dev/null || fail
 fi
 echo "OK"
 


### PR DESCRIPTION
Some (but not all) CM3 fail to boot from FAT formatted partition, which
has more than one sector per cluster.

This does not limit the partition size in any meaningful way and I've tested with a 5GB on disk image. FAT32 file system limit can have up to 2^28 clusters, which with 512B clusters makes up to around 128GB volume.