### PR TITLE
Force FAT32 to disable mkfs.vfat guessing the FAT version to use.

### DIFF
--- a/scripts/opt/raspberrypi-ua-netinst/install.sh
+++ b/scripts/opt/raspberrypi-ua-netinst/install.sh
@@ -1496,9 +1496,9 @@ mdev -s
 
 echo -n "Initializing /boot as vfat... "
 if [ -z "${boot_volume_label}" ]; then
-	mkfs.vfat -s 1 "${bootpartition}" &> /dev/null || fail
+	mkfs.vfat -F 32 -s 1 "${bootpartition}" &> /dev/null || fail
 else
-	mkfs.vfat -s 1 -n "${boot_volume_label}" "${bootpartition}" &> /dev/null || fail
+	mkfs.vfat -F 32 -s 1 -n "${boot_volume_label}" "${bootpartition}" &> /dev/null || fail
 fi
 echo "OK"
 


### PR DESCRIPTION
mkfs.vfat tries to autoguess which FAT version to use (FAT12/FAT16/FAT32) and bases this decision on partition size. Choosing FAT32 with "-F 32" makes sure the one sector per cluster ("-s 1") is always possible.

Example mkfs.vfat -vv on 64MB partition:
```
# qemu-img create -f raw 64m.img 67108864  
Formatting '64m.img', fmt=raw size=67108864

# mkfs.vfat -vv -s 1 64m.img 
mkfs.fat 4.1 (2017-01-24)
Boot jump code is eb 3c
Using 1 reserved sectors
Trying with 1 sectors/cluster:
FAT12: #clu=130275, fatlen=382, maxclu=4080, limit=4080
FAT12: too much clusters
FAT16: #clu=130023, fatlen=508, maxclu=65520, limit=65520
FAT16: too much clusters
FAT16: would be misdetected as FAT12
FAT32: #clu=129053, fatlen=1009, maxclu=129152, limit=268435440
Choosing 12 bits for FAT
mkfs.vfat: Too many clusters for filesystem - try more sectors per cluster

# mkfs.vfat -vv -F 32 -s 1 64m.img 
mkfs.fat 4.1 (2017-01-24)
Boot jump code is eb 58
Using 32 reserved sectors
Trying with 1 sectors/cluster:
FAT12: #clu=130276, fatlen=382, maxclu=4080, limit=4080
FAT12: too much clusters
FAT16: #clu=130024, fatlen=508, maxclu=65520, limit=65520
FAT16: too much clusters
FAT16: would be misdetected as FAT12
FAT32: #clu=129022, fatlen=1009, maxclu=129152, limit=268435440
Using sector 6 as backup boot sector (0 = none)
64m.img has 64 heads and 32 sectors per track,
hidden sectors 0x0000;
logical sector size is 512,
using 0xf8 media descriptor, with 131072 sectors;
drive number 0x80;
filesystem has 2 32-bit FATs and 1 sector per cluster.
FAT size is 1009 sectors, and provides 129022 clusters.
There are 32 reserved sectors.
Volume ID is 6ea21918, no volume label.
```

mkfs.vfat complains on 16MB partitions, but still works:
```
# qemu-img create -f raw 16m.img 16777216 
Formatting '16m.img', fmt=raw size=16777216

# mkfs.vfat -vv -F 32 -s 1 16m.img 
mkfs.fat 4.1 (2017-01-24)
Boot jump code is eb 58
Using 32 reserved sectors
Trying with 1 sectors/cluster:
FAT12: #clu=32544, fatlen=96, maxclu=4080, limit=4080
FAT12: too much clusters
FAT16: #clu=32482, fatlen=127, maxclu=32512, limit=65520
FAT32: #clu=32232, fatlen=252, maxclu=32256, limit=268435440
WARNING: Not enough clusters for a 32 bit FAT!
Using sector 6 as backup boot sector (0 = none)
16m.img has 64 heads and 32 sectors per track,
hidden sectors 0x0000;
logical sector size is 512,
using 0xf8 media descriptor, with 32768 sectors;
drive number 0x80;
filesystem has 2 32-bit FATs and 1 sector per cluster.
FAT size is 252 sectors, and provides 32232 clusters.
There are 32 reserved sectors.
Volume ID is 8be71cff, no volume label.
```

Fixes https://github.com/FooDeas/raspberrypi-ua-netinst/issues/127 and is a bugfix for https://github.com/FooDeas/raspberrypi-ua-netinst/pull/125.