### PR TITLE
build: Support configuration in buildroot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build.conf
+/buildroot.conf
 /bootfs/
 /config/
 !/config/apt/custom_sources.txt

--- a/BUILD.md
+++ b/BUILD.md
@@ -24,11 +24,26 @@ aptitude install git curl bzip2 zip xz-utils gnupg kpartx dosfstools binutils bc
 The following scripts are used to build the raspberrypi-ua-netinst installer, listed in the same order they would be used:
 
 - `clean.sh` - Start with a clean slate by removing everything created by earlier builds. This is not needed on a first build, but won't hurt either.
+
 - `update.sh` - Downloads latest Raspbian packages that will be used to build the installer.
+
 - `build.sh` - Builds the installer initramfs and .zip package for Windows/Mac SD card extraction method. Transfer the .zip package to a Windows/Mac computer, then simply unzip it and copy the files onto a FAT formatted SD card.
-- `buildroot.sh` - Builds the installer SD card image, it requires root privileges and it makes some assumptions like not having any other loop devices in use. You only need to execute this script if you need more than a .zip package. The script produces an .img package and also its bzip2 and xz compressed versions.
+
+- `buildroot.sh` - Builds the installer SD card image, it requires
+  root privileges and it makes some assumptions like not having any
+  other loop devices in use. You only need to execute this script if
+  you need more than a .zip package. The script produces an .img
+  package and then its bzip2 and xz compressed versions, but this is
+  configurable (see below).
 
 To set build options, create a file named `build.conf`, which contains the appropriate variable settings. Supported variables are:
 
 - `mirror_raspbian_cache` - Sets a apt caching proxy for the raspbian.org repository. (e.g. "192.168.0.1:3142")
 - `mirror_raspberrypi_cache` - Sets a apt caching proxy for the raspberrypi.org repository. (e.g. "192.168.0.1:3142")
+
+To set `buildroot` options, create a `buildroot.conf` file (or copy
+`buildroot.conf.sample` as a starting point.)  . By default both bzip2
+and xz compressed versions of the image will be created (and the
+uncompressed image will deleted), but either (or both) can be
+disabled. If both are disabled, the uncompressed image will be left in
+place.

--- a/buildroot.conf.sample
+++ b/buildroot.conf.sample
@@ -1,0 +1,9 @@
+# To customize the buildroot process:
+#
+# Place your settings in this file as described in BUILD.md.
+
+# Controls production of a bz2-compressed image
+# compress_bz2=1
+
+# Controls production of an xz-compressed image
+# compress_xz=1

--- a/buildroot.sh
+++ b/buildroot.sh
@@ -12,6 +12,7 @@ compress_xz=1
 
 # If a configuration file exists, import its settings
 if [ -e buildroot.conf ]; then
+	# shellcheck disable=SC1091
 	source buildroot.conf
 fi
 
@@ -91,6 +92,6 @@ fi
 
 # Cleanup
 
-if [ "$compress_xz" = "1" -o "$compress_bz2" = "1" ]; then
+if [ "$compress_xz" = "1" ] || [ "$compress_bz2" = "1" ]; then
 	rm -f "${image}"
 fi

--- a/buildroot.sh
+++ b/buildroot.sh
@@ -2,6 +2,19 @@
 
 set -e # exit if any command fails
 
+# Set defaults for configurable behavior
+
+# Controls production of a bz2-compressed image
+compress_bz2=1
+
+# Controls production of an xz-compressed image
+compress_xz=1
+
+# If a configuration file exists, import its settings
+if [ -e buildroot.conf ]; then
+	source buildroot.conf
+fi
+
 build_dir=build_dir
 
 version_tag="$(git describe --exact-match --tags HEAD 2> /dev/null || true)"
@@ -60,16 +73,24 @@ else
 fi
 
 # Create archives
-rm -f "${build_dir}/${imagename}.img.xz"
-if ! xz -9v --keep "${image}"; then
-	# This happens e.g. on Raspberry Pi because xz runs out of memory.
-	echo "WARNING: Could not create '${IMG}.xz' variant." >&2
-fi
-rm -f "${imagename}.img.xz"
-mv "${image}.xz" ./
 
-rm -f "${imagename}.img.bz2"
-( bzip2 -9v > "${imagename}.img.bz2" ) < "${image}"
+if [ "$compress_xz" = "1" ]; then
+	rm -f "${image}.xz"
+	if ! xz -9v --keep "${image}"; then
+		# This happens e.g. on Raspberry Pi because xz runs out of memory.
+		echo "WARNING: Could not create '${IMG}.xz' variant." >&2
+	fi
+	rm -f "${imagename}.img.xz"
+	mv "${image}.xz" ./
+fi
+
+if [ "$compress_bz2" = "1" ]; then
+	rm -f "${imagename}.img.bz2"
+	( bzip2 -9v > "${imagename}.img.bz2" ) < "${image}"
+fi
 
 # Cleanup
-rm -f "${image}"
+
+if [ "$compress_xz" = "1" -o "$compress_bz2" = "1" ]; then
+	rm -f "${image}"
+fi


### PR DESCRIPTION
Some users may not want compressed build images, and the compression
processes take quite a bit of time. This patch adds configuration
support to buildroot.sh, allowing the user to decide which (if any)
compressed build images will be produced. If the user disables both
compression formats, the uncompressed image will be left in the
build directory.