### PR TITLE
installer: Config from udhcpc options.

### DIFF
--- a/scripts/opt/raspberrypi-ua-netinst/install.sh
+++ b/scripts/opt/raspberrypi-ua-netinst/install.sh
@@ -931,11 +931,13 @@ if [ "${ip_addr}" = "dhcp" ]; then
 		ifconfig "${ifname}" | grep -F addr: | awk '{print $2}' | cut -d: -f2
                 # Prefix udhcpc variables & source them
 		sed -i -e 's/^/udhcpc_/' /tmp/udhcpc_env
+		# shellcheck disable=SC1091
 		source /tmp/udhcpc_env
 
 		convert_listvariable dhcp_options
 		for i in $dhcp_options; do
 			# Remap udhcpc options to config variables
+			# shellcheck disable=SC2154
 			case $i in
 				"timeserver") timeserver=${udhcpc_ntpsrv} ;;
 				*)


### PR DESCRIPTION
This is a first stab at resolving #156 which aims to read extra options from `udhcpc` and use them to override config options.

The idea is that there is a `dhcp_options` config list, and any item listed there will be read from udhcpc if an equivalent exists. The full list of udhcpc options is given here:

https://udhcp.busybox.net/README.udhcpc

The most useful ones are `hostname` and `domain` - additionally `timeserver` is specially handled since the `udhcpc` option is named `ntpsrv`.

The code seems to work as expected, but probably needs a review, since it's a while since I did anything advanced in bash - especially the sourcing of the variables from the `default.script` and use of `tmpvar` and variable expansion which might not be 'best practice'. So please feel free to comment/suggest improvements/alternatives!