### PR TITLE
build: the --show-progress option was only introduced in wget 1.6

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -124,7 +124,7 @@ download_file() {
 	local download_target=$2
 	if [ -z "${download_target}" ]; then
 		for i in $(seq 1 5); do
-			if ! wget -q --show-progress --no-cache "${download_source}"; then
+			if ! wget -q --no-cache "${download_source}"; then
 				if [ "${i}" != "5" ]; then
 					sleep 5
 				else
@@ -137,7 +137,7 @@ download_file() {
 		done
 	else
 		for i in $(seq 1 5); do
-			if ! wget -q --show-progress --no-cache -O "${download_target}" "${download_source}"; then
+			if ! wget -q --no-cache -O "${download_target}" "${download_source}"; then
 				if [ "${i}" != "5" ]; then
 					sleep 5
 				else

--- a/update.sh
+++ b/update.sh
@@ -122,10 +122,15 @@ packages_sha256=
 download_file() {
 	local download_source=$1
 	local download_target=$2
-	local progress_option=$(wget --show-progress --version &> /dev/null; [ "$?" -ne 2 ] && echo "--show-progress")
+	local progress_option
+	if wget --show-progress --version &> /dev/null; [ "$?" -eq 2 ]; then
+	    progress_option=( )
+	else
+	    progress_option=( --show-progress )
+	fi
 	if [ -z "${download_target}" ]; then
 		for i in $(seq 1 5); do
-			if ! wget $progress_option -q --no-cache "${download_source}"; then
+			if ! wget "${progress_option[@]}" -q --no-cache "${download_source}"; then
 				if [ "${i}" != "5" ]; then
 					sleep 5
 				else
@@ -138,7 +143,7 @@ download_file() {
 		done
 	else
 		for i in $(seq 1 5); do
-			if ! wget $progress_option -q --no-cache -O "${download_target}" "${download_source}"; then
+			if ! wget "${progress_option[@]}" -q --no-cache -O "${download_target}" "${download_source}"; then
 				if [ "${i}" != "5" ]; then
 					sleep 5
 				else

--- a/update.sh
+++ b/update.sh
@@ -122,9 +122,10 @@ packages_sha256=
 download_file() {
 	local download_source=$1
 	local download_target=$2
+	local progress_option=$(wget --show-progress --version &> /dev/null; [ "$?" -ne 2 ] && echo "--show-progress")
 	if [ -z "${download_target}" ]; then
 		for i in $(seq 1 5); do
-			if ! wget -q --no-cache "${download_source}"; then
+			if ! wget $progress_option -q --no-cache "${download_source}"; then
 				if [ "${i}" != "5" ]; then
 					sleep 5
 				else
@@ -137,7 +138,7 @@ download_file() {
 		done
 	else
 		for i in $(seq 1 5); do
-			if ! wget -q --no-cache -O "${download_target}" "${download_source}"; then
+			if ! wget $progress_option -q --no-cache -O "${download_target}" "${download_source}"; then
 				if [ "${i}" != "5" ]; then
 					sleep 5
 				else


### PR DESCRIPTION
On my development machine, the build fails because my distro ships with wget 1.15, and the --show-progress argument to wget wasn't introduced until 1.16: http://savannah.gnu.org/forum/forum.php?forum_id=8133.

It's possible to use some slightly hair-raising conditionals to turn it on if available, e.g. https://stackoverflow.com/questions/4686464/how-to-show-wget-progress-bar-only/32491843#32491843, but IMHO the benefit of this doesn't justify the complexity.