### PR TITLE
build: have travis build release packages again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,49 @@
 language: bash
-sudo: false
-install: gem install mdl
-script:
- - bash -c 'shopt -s globstar; shellcheck **/*.sh'
- - mdl --verbose --rules '~MD013, ~MD036' .
+
+stages:
+- name: lint
+- name: build
+
+jobs:
+  include:
+  - stage: lint
+    name: Linting project
+    sudo: false
+    install: gem install mdl
+    script:
+    - bash -c 'shopt -s globstar; shellcheck **/*.sh'
+    - mdl --verbose --rules '~MD013, ~MD036' .
+  - stage: build
+    name: Building release packages
+    sudo: true
+    addons:
+      apt:
+        update: true
+        packages:
+        - git
+        - curl
+        - bzip2
+        - zip
+        - xz-utils
+        - gnupg
+        - kpartx
+        - dosfstools
+        - binutils
+        - bc
+        - wget
+        - kmod
+        - cpio
+    script:
+    - bash update.sh
+    - bash build.sh
+    - sudo bash buildroot.sh
+    deploy:
+      provider: releases
+      api_key: "$GITHUB_OAUTH_TOKEN"
+      skip_cleanup: true
+      on:
+        tags: true
+      file_glob: true
+      file:
+      - "raspberrypi-ua-netinst*"
+      - "*/raspberrypi-ua-netinst*"


### PR DESCRIPTION
Noticed the original travis PR(#129) had targeted building the release, but didn't see much more discussion beyond periodic download failures. If that becomes a regular problem, the build script behavior could be adjusted to include retries or consider mirrors.

So I brought it back with deploy to release support.
Just needs the `GITHUB_OAUTH_TOKEN` variable set in travis.