### PR TITLE
Remove copying of 'rmt' into installer filesystem

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -427,9 +427,7 @@ function create_cpio {
 
 	# tar components
 	cp --preserve=xattr,timestamps tmp/bin/tar rootfs/bin/
-	cp --preserve=xattr,timestamps tmp/etc/rmt rootfs/etc/
 	cp --preserve=xattr,timestamps tmp/usr/lib/mime/packages/tar rootfs/usr/lib/mime/packages/
-	cp --preserve=xattr,timestamps tmp/usr/sbin/rmt-tar rootfs/usr/sbin/
 	cp --preserve=xattr,timestamps tmp/usr/sbin/tarcat rootfs/usr/sbin/
 
 	# fdisk components


### PR DESCRIPTION
On Debian systems, /etc/rmt is a dangling symlink until after a package
which provides 'rmt' is installed (at which point the links are
/etc/rmt -> /usr/sbin/rmt -> /etc/alternatives/rmt). During the build
of the installer, alternatives are not processed, so /etc/rmt is a
link which points into the filesystem of the build host (not the build
directory).

If the build is being done on a Debian-style system, the installer will
end up with an /etc/rmt which is a binary from the host, which may not
even operate on the Raspberry Pi. If the build is being done on a
non-Debian-style system, the cp command in create_cpio() will probably
fail.

Since the installer does not connect to other systems to process tar
archives, rmt is not needed, so this patch removes any attempt to copy
it into the installer.

Signed-off-by: Kevin P. Fleming <kevin@km6g.us>