### PR TITLE
Improve RTC handling

### DIFF
--- a/doc/INSTALL_CUSTOM.md
+++ b/doc/INSTALL_CUSTOM.md
@@ -55,7 +55,7 @@ Note that if the networking configuration is set to use DHCP, no additional pack
 | `sound_usb_first` | `0` | `0`/`1` | Set to "1" to define USB audio as default if onboard audio is also enabled. The options `sound_enable=1` and `sound_usb_enable=1` have to be set to take effect. |
 | `camera_enable` | `0` | `0`/`1` | Set to "1" to enable the camera module. This enables all camera-related parameters in config.txt. |
 | `camera_disable_led` | `0` | `0`/`1` | Disables the camera LED. The option `camera_enable=1` has to be set to take effect. |
-| `rtc` |  | `ds1307`/  `ds1339`/  `ds3231`/  `mcp7940x`/  `mcp7941x`/  `pcf2127`/  `pcf8523`/  `pcf8563` | Select an RTC if it is connected via I²C. |
+| `rtc` |  | `ds1307`/  `ds1339`/  `ds3231`/  `mcp7940x`/  `mcp7941x`/  `pcf2127`/  `pcf8523`/  `pcf8563`/  `abx80x` | Select an RTC if it is connected via I²C. |
 | `dt_overlays` |  |  | Enables additional device tree overlays (comma separated and quoted). (e.g. 'dt_overlays="hifiberry-dac,lirc-rpi"') |
 
 ## SSH


### PR DESCRIPTION
* Add 'abx80x' to list of possible RTC drivers

* Add 'module_enable' function in installer script for modules to be loaded
  in installed system

* Use 'dtoverlay_enable' function in various places it was not being used

* Ensure module for the RTC has been loaded during installation

* Stop adding 'hwclock' call to /etc/rc.local as it is no longer needed
  - systems using sysvinit already have a udev rule to do this
  - systems using systemd will use service unit described below

* Add systemd service unit to read RTC on startup
  - as seen in Debian bug 855203, systems using systemd don't read the RTC
    during startup if the RTC's driver is loaded as a module; since all
    Raspberry Pi kernels are configured this way, a service unit is required
    to read the RTC during system startup

* Ensure module for the RTC will be loaded in installed system

* Ensure that RTC date/time is set in UTC mode

The 'ensure module loaded' bits are required because at least one RTC module
(abx80x) is not automatically loaded even though the proper Device Tree overlay
has been configured. For those which are autoloaded, having the module name
in /etc/modules (or /etc/modules-load.d/rtc.conf) won't cause any harm.

Signed-off-by: Kevin P. Fleming <kevin@km6g.us>