### PR TITLE
Minor fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,12 @@ When an error occurs during install, the logfile is placed in the `raspberrypi-u
 
 ## Reinstalling or replacing an existing system
 
-If you want to reinstall with the same settings you did your first install you can just move the original _config.txt_ back and reboot.
+If you want to reinstall with the same settings you did your first install you can just copy the original _config.txt_ back and reboot.
+
+Note: If the original installation was performed with `cleanup` set to `1`, then the files necessary for a reinstallation will not be available.
 
 ```
-mv /boot/raspberrypi-ua-netinst/reinstall/config.txt /boot/config.txt
+cp /boot/raspberrypi-ua-netinst/config.txt /boot/config.txt
 reboot
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -717,7 +717,7 @@ rm -rf tmp && mkdir tmp
 
 # extract debs
 for i in ../packages/*.deb; do
-	cd tmp && ar x "../${i}" && tar -xf data.tar.*; rm data.tar.*; cd ..
+	cd tmp && ar x "../${i}" && tar -xf data.tar.*; rm -f data.tar.* control.tar.* debian-binary; cd ..
 done
 
 # get kernel versions

--- a/build.sh
+++ b/build.sh
@@ -624,7 +624,7 @@ function create_cpio {
 
 	# libtinfo6 components
 	cp --preserve=xattr,timestamps tmp/lib/*/libtinfo.so.6.* rootfs/lib/libtinfo.so.6
-	cp --preserve=xattr,timestamps tmp/usr/lib/*/libtic.so.6.* rootfs/usr/lib/libtinfo.so.6
+	cp --preserve=xattr,timestamps tmp/usr/lib/*/libtic.so.6.* rootfs/usr/lib/libtic.so.6
 
 	# libuuid1 components
 	cp --preserve=xattr,timestamps tmp/lib/*/libuuid.so.1.* rootfs/lib/libuuid.so.1

--- a/build.sh
+++ b/build.sh
@@ -181,6 +181,7 @@ function create_cpio {
 		mkdir -p "rootfs/lib/modules/${kernel}/kernel/drivers/net"
 		mkdir -p "rootfs/lib/modules/${kernel}/kernel/net"
 	done
+	cp_kernelfiles tmp/lib/modules/kernel*/kernel/net/ipv6 rootfs/lib/modules/kernel*/kernel/net/
 	cp_kernelfiles tmp/lib/modules/kernel*/kernel/net/mac80211 rootfs/lib/modules/kernel*/kernel/net/
 	cp_kernelfiles tmp/lib/modules/kernel*/kernel/net/rfkill rootfs/lib/modules/kernel*/kernel/net/
 	cp_kernelfiles tmp/lib/modules/kernel*/kernel/net/wireless rootfs/lib/modules/kernel*/kernel/net/

--- a/build.sh
+++ b/build.sh
@@ -746,7 +746,9 @@ mv raspberrypi-ua-netinst.cpio.gz bootfs/raspberrypi-ua-netinst/initramfs.gz
 	echo "initramfs initramfs.gz"
 	echo "gpu_mem=16"
 	echo "[pi3]"
-	echo "enable_uart=1"
+	echo "dtoverlay=disable-bt"
+	echo "[pi4]"
+	echo "dtoverlay=disable-bt"
 } >> bootfs/raspberrypi-ua-netinst/config.txt
 
 cp bootfs/raspberrypi-ua-netinst/config.txt bootfs/config.txt

--- a/build.sh
+++ b/build.sh
@@ -725,28 +725,33 @@ get_kernels
 
 # initialize bootfs
 rm -rf bootfs
-mkdir bootfs
+mkdir -p bootfs/raspberrypi-ua-netinst
 
 # raspberrypi-bootloader components and kernel
 cp --preserve=xattr,timestamps -r tmp/boot/* bootfs/
+mv bootfs/kernel*.img bootfs/raspberrypi-ua-netinst/
+mv bootfs/*.dtb bootfs/raspberrypi-ua-netinst/
+mv bootfs/overlays bootfs/raspberrypi-ua-netinst/
 
 if [ ! -f bootfs/config.txt ] ; then
 	touch bootfs/config.txt
 fi
 
 create_cpio
-mkdir -p bootfs/raspberrypi-ua-netinst
-mv raspberrypi-ua-netinst.cpio.gz bootfs/raspberrypi-ua-netinst/
+mv raspberrypi-ua-netinst.cpio.gz bootfs/raspberrypi-ua-netinst/initramfs.gz
 
 {
 	echo "[all]"
-	echo "initramfs raspberrypi-ua-netinst/raspberrypi-ua-netinst.cpio.gz"
+	echo "os_prefix=raspberrypi-ua-netinst/"
+	echo "initramfs initramfs.gz"
 	echo "gpu_mem=16"
 	echo "[pi3]"
 	echo "enable_uart=1"
-} >> bootfs/config.txt
+} >> bootfs/raspberrypi-ua-netinst/config.txt
 
-echo "dwc_otg.lpm_enable=0 consoleblank=0 console=serial0,115200 console=tty1 elevator=deadline rootwait" > bootfs/cmdline.txt
+cp bootfs/raspberrypi-ua-netinst/config.txt bootfs/config.txt
+
+echo "dwc_otg.lpm_enable=0 consoleblank=0 console=serial0,115200 console=tty1 elevator=deadline rootwait" > bootfs/raspberrypi-ua-netinst/cmdline.txt
 
 if [ ! -f bootfs/TIMEOUT ] ; then
 	touch bootfs/TIMEOUT

--- a/buildroot.sh
+++ b/buildroot.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# shellcheck source=./buildroot.conf
+# shellcheck disable=SC1091
 
 set -e # exit if any command fails
 
@@ -14,9 +16,8 @@ compress_xz=1
 use_sudo=0
 
 # If a configuration file exists, import its settings
-if [ -e buildroot.conf ]; then
-	# shellcheck disable=SC1091
-	source buildroot.conf
+if [ -r buildroot.conf ]; then
+	source <(tr -d "\015" < buildroot.conf)
 fi
 
 if [ "$use_sudo" = "1" ]; then

--- a/doc/INSTALL_CUSTOM.md
+++ b/doc/INSTALL_CUSTOM.md
@@ -27,7 +27,7 @@
 
 | Preset | Packages |
 |---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `base` | _\<essential\>,apt,kmod_ |
+| `base` | _\<essential\>,apt,gnupg,kmod_ |
 | `minimal` | _\<base\>,cpufrequtils,fake-hwclock,ifupdown,net-tools,ntp,openssh-server,dosfstools,raspberrypi-sys-mods_ |
 | `server` | _\<minimal\>,systemd-sysv,vim-tiny,iputils-ping,wget,ca-certificates,rsyslog,cron,dialog,locales,tzdata,less,man-db,logrotate,bash-completion,console-setup,apt-utils,libraspberrypi-bin,raspi-copies-and-fills_ |
 

--- a/scripts/opt/raspberrypi-ua-netinst/install.sh
+++ b/scripts/opt/raspberrypi-ua-netinst/install.sh
@@ -719,15 +719,6 @@ variables_set_defaults
 preinstall_reboot=0
 echo
 echo "Checking if config.txt needs to be modified before starting installation..."
-# Reinstallation
-if [ -e "/boot/raspberrypi-ua-netinst/reinstall/kernel.img" ] && [ -e "/boot/raspberrypi-ua-netinst/reinstall/kernel7.img" ] && [ -e "/boot/raspberrypi-ua-netinst/reinstall/kernel7l.img" ] ; then
-	echo -n "  Reinstallation requested! Restoring files... "
-	mv /boot/raspberrypi-ua-netinst/reinstall/kernel.img /boot/kernel.img
-	mv /boot/raspberrypi-ua-netinst/reinstall/kernel7.img /boot/kernel7.img
-	mv /boot/raspberrypi-ua-netinst/reinstall/kernel7l.img /boot/kernel7l.img
-	echo "OK"
-	preinstall_reboot=1
-fi
 # HDMI settings
 if [ "${hdmi_system_only}" = "0" ]; then
 	echo -n "  Setting HDMI options... "
@@ -2225,14 +2216,6 @@ echo
 # remove cdebootstrap-helper-rc.d which prevents rc.d scripts from running
 echo -n "Removing cdebootstrap-helper-rc.d... "
 chroot /rootfs /usr/bin/dpkg -r cdebootstrap-helper-rc.d &> /dev/null || fail
-echo "OK"
-
-echo -n "Preserving original config.txt and kernels... "
-mkdir -p /rootfs/boot/raspberrypi-ua-netinst/reinstall
-cp /rootfs/boot/config.txt /rootfs/boot/raspberrypi-ua-netinst/reinstall/config.txt
-cp /rootfs/boot/kernel.img /rootfs/boot/raspberrypi-ua-netinst/reinstall/kernel.img
-cp /rootfs/boot/kernel7.img /rootfs/boot/raspberrypi-ua-netinst/reinstall/kernel7.img
-cp /rootfs/boot/kernel7l.img /rootfs/boot/raspberrypi-ua-netinst/reinstall/kernel7l.img
 echo "OK"
 
 echo -n "Configuring bootloader to start the installed system..."

--- a/scripts/opt/raspberrypi-ua-netinst/install.sh
+++ b/scripts/opt/raspberrypi-ua-netinst/install.sh
@@ -1702,6 +1702,7 @@ if [ -n "${username}" ]; then
 			else
 				echo -n "... "
 				echo "${user_ssh_pubkey}" > "/rootfs/home/${username}/.ssh/authorized_keys"
+				echo "OK"
 			fi
 			echo -n "  Setting owner as '${username}' on SSH directory... "
 			chroot /rootfs /bin/chown -R "${username}:${username}" "/home/${username}/.ssh" || fail

--- a/scripts/opt/raspberrypi-ua-netinst/install.sh
+++ b/scripts/opt/raspberrypi-ua-netinst/install.sh
@@ -1199,7 +1199,8 @@ if [ -z "${cdebootstrap_cmdline}" ]; then
 	fi
 
 	# base
-	base_packages="kmod"
+	# gnupg is required for 'apt-key' used later in the script
+	base_packages="kmod,gnupg"
 	base_packages="${custom_packages},${base_packages}"
 	if [ "${init_system}" = "systemd" ]; then
 		base_packages="${base_packages},libpam-systemd"

--- a/scripts/opt/raspberrypi-ua-netinst/install.sh
+++ b/scripts/opt/raspberrypi-ua-netinst/install.sh
@@ -533,6 +533,7 @@ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bu
 echo "export PATH=${PATH}" > /etc/profile
 
 mount -t proc proc /proc
+ln -sf /proc/mounts /etc/mtab
 mount -t sysfs sysfs /sys
 
 mount -t tmpfs -o size=64k,mode=0755 tmpfs /dev

--- a/scripts/opt/raspberrypi-ua-netinst/install.sh
+++ b/scripts/opt/raspberrypi-ua-netinst/install.sh
@@ -810,6 +810,7 @@ echo
 echo "Network configuration:"
 echo "  ifname = ${ifname}"
 echo "  ip_addr = ${ip_addr}"
+echo "  ip_ipv6 = ${ip_ipv6}"
 
 if [ "${ip_addr}" != "dhcp" ]; then
 	ip_addr_o1="$(echo "${ip_addr}" | awk -F. '{print $1}')"
@@ -988,6 +989,12 @@ else
 	for i in ${ip_nameservers}; do
 		echo "nameserver ${i}" >> /etc/resolv.conf
 	done
+	echo "OK"
+fi
+
+if [ "${ip_ipv6}" = "1" ]; then
+	echo -n "Enabling IPv6 support... "
+	modprobe ipv6 || fail
 	echo "OK"
 fi
 

--- a/scripts/opt/raspberrypi-ua-netinst/install.sh
+++ b/scripts/opt/raspberrypi-ua-netinst/install.sh
@@ -520,7 +520,7 @@ mkdir -p /usr/bin
 mkdir -p /usr/sbin
 mkdir -p /var/run
 mkdir -p /etc/raspberrypi-ua-netinst
-mkdir -p /rootfs/boot
+mkdir -p /rootfs
 mkdir -p /tmp
 mkdir -p "${tmp_bootfs}"
 mkdir -p /opt/busybox/bin

--- a/update.sh
+++ b/update.sh
@@ -456,10 +456,14 @@ fi
 	download_remote_file https://downloads.raspberrypi.org/raspbian/ "boot.tar.xz" xzcat ./config.txt
 	sed -i "s/^\(dtparam=audio=on\)/#\1/" config.txt # disable audio
 	{
-		echo -e "\n[pi3]"
-		echo -e "# Enable serial port\nenable_uart=1"
-		echo -e "\n[all]"
-		echo -e "# Add other config parameters below this line."
+		echo ""
+		echo "[pi3]"
+		echo "dtoverlay=disable-bt"
+		echo "[pi4]"
+		echo "dtoverlay=disable-bt"
+		echo ""
+		echo "[all]"
+		echo "# Add other config parameters below this line."
 	} >> config.txt
 	chmod 644 config.txt
 	cd ../.. || exit 1


### PR DESCRIPTION
- Enable IPv6 during installation if enabled in final system 
- Improve reinstallation support (alternative, simpler, solution to the problem identified in #190)
- Copy libtic library to proper file name 
- Cleanup additional files from .deb unpacking
- Avoid creation of an unnecessary directory
- Add /etc/mtab symbolic link (in installer filesystem)
- gnupg package is required 
- Add missing 'OK' during non-root-user SSH configuration
- Use CR-LF translation when reading buildroot.conf
- Improve console-on-UART handling (for Pi3 and Pi4)