### PR TITLE
Add outbound telnet support

### DIFF
--- a/doc/INSTALL_CUSTOM.md
+++ b/doc/INSTALL_CUSTOM.md
@@ -141,7 +141,9 @@ Note that if the networking configuration is set to use DHCP, no additional pack
 | `cleanup_logfiles` | `0` | `0`/`1` | Removes installer log files after success. |
 | `cmdline` | `"dwc_otg.lpm_enable=0 console=serial0,115200 console=tty1 elevator=deadline fsck.repair=yes"` |  |  |
 | `final_action` | `reboot` | `reboot`/  `poweroff`/  `halt`/  `console` | Action at the end of install. |
-| `installer_telnet` | `1` | `0`/`1` | Send installer console output via telnet. |
+| `installer_telnet` | `listen` | `none`/`connect`/`listen` | Connect to, or listen for, a telnet connection to send installer console output. |
+| `installer_telnet_host` | | | Host name or address to use when `installer_telnet` is set to `connect`. |
+| `installer_telnet_port` | '9923' |  | Port number to use when `installer_telnet` is set to `connect`. |
 | `installer_retries` | `3` |  | Number of retries if installation fails. |
 | `installer_networktimeout` | `15` |  | Timeout in seconds for network interface initialization. |
 | `installer_pkg_updateretries` | `3` |  | Number of retries if package update fails. |

--- a/scripts/opt/raspberrypi-ua-netinst/install.sh
+++ b/scripts/opt/raspberrypi-ua-netinst/install.sh
@@ -77,6 +77,8 @@ variables_reset() {
 	cmdline=
 	rootfstype=
 	installer_telnet=
+	installer_telnet_host=
+	installer_telnet_port=
 	installer_retries=
 	installer_networktimeout=
 	installer_pkg_updateretries=
@@ -126,6 +128,15 @@ variables_set_defaults() {
 	if [ -n "${ip_broadcast}" ]; then
 		echo "  Variable 'ip_broadcast' is deprecated. This variable will be ignored!"
 	fi
+	if [ "${installer_telnet}" = "1" ]; then
+		echo "'installer_telnet' now accepts 'connect' and 'listen' settings, not '1'."
+		echo "'listen' mode is being enabled."
+		installer_telnet="listen"
+	elif [ "${installer_telnet}" = "0" ]; then
+		echo "'installer_telnet' now accepts 'connect' and 'listen' settings, not '0'."
+		echo "Neither mode is enabled."
+		installer_telnet="none"
+	fi
 
 	# set config defaults
 	variable_set "preset" "server"
@@ -153,7 +164,8 @@ variables_set_defaults() {
 	variable_set "cmdline" "dwc_otg.lpm_enable=0 console=serial0,115200 console=tty1 elevator=deadline fsck.repair=yes"
 	variable_set "rootfstype" "f2fs"
 	variable_set "final_action" "reboot"
-	variable_set "installer_telnet" "1"
+	variable_set "installer_telnet" "listen"
+	variable_set "installer_telnet_port" "9923"
 	variable_set "installer_retries" "3"
 	variable_set "installer_networktimeout" "15"
 	variable_set "installer_pkg_updateretries" "3"
@@ -992,15 +1004,24 @@ else
 fi
 
 # Start telnet console output
-if [ "${installer_telnet}" = "1" ]; then
+if [ "${installer_telnet}" = "listen" ] || [ "${installer_telnet}" = "connect" ]; then
 	mkfifo telnet.pipe
 	mkfifo /dev/installer-telnet
 	tee < telnet.pipe /dev/installer-telnet &
+	if [ "${installer_telnet}" = "listen" ]; then
+		nc_opts=(-klC -p 23)
+	else # connect
+		if [ -z "${installer_telnet_host}" ]; then
+			echo "'installer_telnet' set to 'connect' but no 'installer_telnet_host' specified."
+			echo "Telnet mode will not be enabled."
+		fi
+		nc_opts=(-C "${installer_telnet_host}" "${installer_telnet_port}")
+	fi
 	while IFS= read -r line; do
 		if [[ ! "${line}" =~ userpw|rootpw ]]; then
 			echo "${line}"
 		fi
-	done < "/dev/installer-telnet" | /bin/nc -klC -p 23 > /dev/null &
+	done < "/dev/installer-telnet" | /bin/nc "${nc_opts[@]}" > /dev/null &
 	exec &> telnet.pipe
 	rm telnet.pipe
 	echo "Printing console to telnet output started."


### PR DESCRIPTION
`installer_telnet` can now be set to `listen` (the previous mode), `connect`, or `none`. When `connect` is set, the installer will make an outbound connection to a specified host and port to deliver console output during the installation process.